### PR TITLE
Ygaudet livd fixes

### DIFF
--- a/input/fsh/bundle-uv-livd.fsh
+++ b/input/fsh/bundle-uv-livd.fsh
@@ -66,4 +66,4 @@ Description: "LIVD constraints on the Bundle resource"
 * entry.response.etag ^mustSupport = false
 * entry.response.lastModified ^mustSupport = false
 * entry.response.outcome ^mustSupport = false
-* signature 0..0
+

--- a/input/fsh/catalog-uv-livd.fsh
+++ b/input/fsh/catalog-uv-livd.fsh
@@ -17,7 +17,9 @@ Description: "Profile on the Composition resource to specify and organize the se
 * extension ^slicing.discriminator[0].type = #value
 * extension ^slicing.discriminator[0].path = "url"
 * extension ^slicing.rules = #open
-* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-region named CatalogRegion 0..* MS
+* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-version named ext-version 1..1 MS
+* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-language named ext-language 1..1 MS
+* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-region named ext-region 0..1 MS
 * extension contains http://hl7.org/fhir/StructureDefinition/note named CatalogNote 0..* MS
 * extension[CatalogNote].value[x] only Annotation
 * extension[CatalogNote].value[x] 1..1 MS

--- a/input/fsh/catalog-uv-livd.fsh
+++ b/input/fsh/catalog-uv-livd.fsh
@@ -90,17 +90,17 @@ Description: "Profile on the Composition resource to specify and organize the se
 * type.coding only Coding
 * type.coding ^definition = "Provides the LOINC Code for the LIVD Mapping Publication."
 * type.coding.system 1..1 MS
-* type.coding.system only uri
+* type.coding.system = "http://loinc.org"
 * type.coding.system ^short = "LOINC Coding System"
 * type.coding.version 1..1 MS
 * type.coding.version only string
 * type.coding.version ^short = "LOINC Code Version"
 * type.coding.code 1..1 MS
-* type.coding.code only code
+* type.coding.code = #90370-8
 * type.coding.code ^short = "LIVD Mapping Publication LOINC Code"
 * type.coding.code ^definition = "LOINC Code representing the LIVD Mapping Publication."
 * type.coding.display 1..1 MS
-* type.coding.display only string
+* type.coding.display = "LIVD mapping data set"
 * type.coding.userSelected 0..0
 * type.coding.userSelected only boolean
 * type.coding.userSelected ^mustSupport = false

--- a/input/fsh/catalog-uv-livd.fsh
+++ b/input/fsh/catalog-uv-livd.fsh
@@ -18,6 +18,10 @@ Description: "Profile on the Composition resource to specify and organize the se
 * extension ^slicing.discriminator[0].path = "url"
 * extension ^slicing.rules = #open
 * extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-region named CatalogRegion 0..* MS
+* extension contains http://hl7.org/fhir/StructureDefinition/note named CatalogNote 0..* MS
+* extension[CatalogNote].value[x] only Annotation
+* extension[CatalogNote].value[x] 1..1 MS
+* extension[CatalogNote].value[x] ^short = "Note annotation for the catalog"
 * language 1..1 MS
 * language only code
 * language ^short = "Publication Language"

--- a/input/fsh/devicedefinition-uv-livd.fsh
+++ b/input/fsh/devicedefinition-uv-livd.fsh
@@ -36,6 +36,7 @@ Description: "Profile on the DeviceDefinition resource for representing the devi
 * extension ^slicing.discriminator[0].path = "url"
 * extension ^slicing.rules = #open
 * extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-deviceDefinition-hasPart named DeviceDefinitionHasPart 0..* MS
+* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-deviceDefinition-classification-type named DeviceDefinitionClassificationType 0..* MS
 * udiDeviceIdentifier 0..1 MS
 * udiDeviceIdentifier ^comment = "In this profile only a type of device can be represented where the UDI only identifies the type of the device."
 * udiDeviceIdentifier ^mapping[0].identity = "rim"

--- a/input/fsh/devicedefinition-uv-livd.fsh
+++ b/input/fsh/devicedefinition-uv-livd.fsh
@@ -31,6 +31,11 @@ Description: "Profile on the DeviceDefinition resource for representing the devi
 * id 1..1
 * identifier 0..*
 * identifier ^mustSupport = false
+* extension ..* MS
+* extension ^slicing.discriminator[0].type = #value
+* extension ^slicing.discriminator[0].path = "url"
+* extension ^slicing.rules = #open
+* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-deviceDefinition-hasPart named DeviceDefinitionHasPart 0..* MS
 * udiDeviceIdentifier 0..1 MS
 * udiDeviceIdentifier ^comment = "In this profile only a type of device can be represented where the UDI only identifies the type of the device."
 * udiDeviceIdentifier ^mapping[0].identity = "rim"

--- a/input/fsh/extensions.fsh
+++ b/input/fsh/extensions.fsh
@@ -112,3 +112,21 @@ Description: "A device that is part of the current one."
 * ^context[0].expression = "DeviceDefinition"
 * value[x] only Reference(http://hl7.org/fhir/StructureDefinition/DeviceDefinition)
 * value[x] 1..1 MS
+
+Extension: DeviceDefinitionClassificationType
+Id: ext-deviceDefinition-classification-type
+Title: "DeviceDefinition Classification Type"
+Description: "A classification or risk class of the device model."
+* ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg"
+* ^extension[0].valueCode = #oo
+* ^extension[1].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
+* ^extension[1].valueCode = #draft
+* ^extension[2].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
+* ^extension[2].valueInteger = 1
+* ^extension[3].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-type-characteristics"
+* ^extension[3].valueCode = #can-bind
+* ^context[0].type = #element
+* ^context[0].expression = "DeviceDefinition"
+* value[x] only CodeableConcept
+* value[x] 1..1 MS
+* value[x] from http://hl7.org/fhir/ValueSet/device-type (extensible)

--- a/input/fsh/extensions.fsh
+++ b/input/fsh/extensions.fsh
@@ -96,3 +96,19 @@ Description: "Provides the language of the LIVD Mapping Publication."
 * url = "http://hl7.org/fhir/uv/livd/StructureDefinition/ext-language" (exactly)
 * valueCodeableConcept 1..1
 * valueCodeableConcept only CodeableConcept
+
+
+Extension: DeviceDefinitionHasPart
+Id: ext-deviceDefinition-hasPart
+Title: "DeviceDefinition hasPart"
+Description: "A device that is part of the current one."
+* ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg"
+* ^extension[0].valueCode = #oo
+* ^extension[1].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status"
+* ^extension[1].valueCode = #draft
+* ^extension[2].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
+* ^extension[2].valueInteger = 0
+* ^context[0].type = #element
+* ^context[0].expression = "DeviceDefinition"
+* value[x] only Reference(http://hl7.org/fhir/StructureDefinition/DeviceDefinition)
+* value[x] 1..1 MS

--- a/input/fsh/extensions.fsh
+++ b/input/fsh/extensions.fsh
@@ -64,3 +64,35 @@ Description: "Provides the region(s), such as country, state, continent, set of 
 * url = "http://hl7.org/fhir/uv/livd/StructureDefinition/ext-region" (exactly)
 * valueCodeableConcept 1..1
 * valueCodeableConcept only CodeableConcept
+
+Extension: LIVDVersion
+Id: ext-version
+Title: "LIVD Version"
+Description: "Provides the version of the LIVD Mapping Publication."
+* ^version = "1.0.0"
+* ^publisher = "HL7 International / Orders and Observations"
+* ^contact[0].telecom[0].system = #url
+* ^contact[0].telecom[0].value = "http://www.hl7.org/Special/committees/orders"
+* ^jurisdiction[0].coding[0].system = "http://unstats.un.org/unsd/methods/m49/m49.htm"
+* ^jurisdiction[0].coding[0].code = #001
+* ^context[0].type = #element
+* ^context[0].expression = "Composition"
+* url = "http://hl7.org/fhir/uv/livd/StructureDefinition/ext-version" (exactly)
+* valueCodeableConcept 1..1
+* valueCodeableConcept only CodeableConcept
+
+Extension: LIVDLanguage
+Id: ext-language
+Title: "LIVD Language"
+Description: "Provides the language of the LIVD Mapping Publication."
+* ^version = "1.0.0"
+* ^publisher = "HL7 International / Orders and Observations"
+* ^contact[0].telecom[0].system = #url
+* ^contact[0].telecom[0].value = "http://www.hl7.org/Special/committees/orders"
+* ^jurisdiction[0].coding[0].system = "http://unstats.un.org/unsd/methods/m49/m49.htm"
+* ^jurisdiction[0].coding[0].code = #001
+* ^context[0].type = #element
+* ^context[0].expression = "Composition"
+* url = "http://hl7.org/fhir/uv/livd/StructureDefinition/ext-language" (exactly)
+* valueCodeableConcept 1..1
+* valueCodeableConcept only CodeableConcept

--- a/input/fsh/observationdefinition-uv-livd.fsh
+++ b/input/fsh/observationdefinition-uv-livd.fsh
@@ -23,8 +23,6 @@ Description: "Profile on the ObservationDefinition resource for representing the
 * extension ^slicing.discriminator[0].path = "url"
 * extension ^slicing.rules = #open
 * extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-livd-devicedefinition named ObservationDefinitionDevice 1..* MS
-* extension contains http://hl7.org/fhir/uv/livd/StructureDefinition/ext-vendorReferenceIdentifier named ObservationDefinitionVendorReferenceIdentifier 0..1 MS
-* extension[ObservationDefinitionVendorReferenceIdentifier] ^comment = "Provides an alternate reference identifier by which the IVD Test is known.  Only the identifier.value is required."
 * category 0..0
 * category only CodeableConcept
 * category ^definition = "A code that classifies the general type of observation."
@@ -48,8 +46,15 @@ Description: "Profile on the ObservationDefinition resource for representing the
 * code ^mapping[0].map = "OM1-2"
 * code ^mapping[1].identity = "rim"
 * code ^mapping[1].map = "code"
-* identifier 0..1 MS
 * id 1..1
+* identifier 0..* MS
+* identifier ^slicing.discriminator[0].type = #value
+* identifier ^slicing.discriminator[0].path = "type.coding.code"
+* identifier ^slicing.rules = #open
+* identifier contains VendorReferenceID 0..1 MS
+* identifier[VendorReferenceID].type 1..1
+* identifier[VendorReferenceID].type.coding.code = #LIVDVendorReferenceID
+* identifier[VendorReferenceID].value 1..1
 * permittedDataType 0..1 MS
 * permittedDataType only code
 * permittedDataType ^definition = "data type allowed for the result of the observation."

--- a/input/fsh/observationdefinition-uv-livd.fsh
+++ b/input/fsh/observationdefinition-uv-livd.fsh
@@ -36,6 +36,10 @@ Description: "Profile on the ObservationDefinition resource for representing the
 * category ^mapping[0].map = ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"DEF\"].code"
 * code 1..1 MS
 * code only CodeableConcept
+* code.coding 1..*
+* code.coding.system 1..1
+* code.coding.code 1..1
+* code.coding.display 1..1
 * code ^definition = "Describes what will be observed. Sometimes this is called the observation \"name\"."
 * code ^comment = "Contains both the IVD Test Code and Name of the analyte."
 * code ^requirements = "Knowing what kind of observation is being made is essential to understanding the observation."
@@ -44,7 +48,8 @@ Description: "Profile on the ObservationDefinition resource for representing the
 * code ^mapping[0].map = "OM1-2"
 * code ^mapping[1].identity = "rim"
 * code ^mapping[1].map = "code"
-* identifier 0..* MS
+* identifier 0..1 MS
+* id 1..1
 * permittedDataType 0..1 MS
 * permittedDataType only code
 * permittedDataType ^definition = "data type allowed for the result of the observation."

--- a/oids.ini
+++ b/oids.ini
@@ -2,15 +2,15 @@
 information1 = This file stores the OID assignments for resources defined in this IG.
 information2 = It must be added to git and committed when resources are added or their id is changed
 information3 = You should not generally need to edit this file, but if you do:
-information4 =  (a) you can change the id of a resource (left side) if you change it's actual id in your source, to maintain OID consistency
-information5 =  (b) you can change the oid of the resource to an OID you assign manually. If you really know what you're doing with OIDs
+information4 = (a) you can change the id of a resource (left side) if you change it's actual id in your source, to maintain OID consistency
+information5 = (b) you can change the oid of the resource to an OID you assign manually. If you really know what you're doing with OIDs
 information6 = There is never a reason to edit anything else
 
 [Key]
 CodeSystem = 2
 ValueSet = 4
 ConceptMap = 1
-StructureDefinition = 10
+StructureDefinition = 12
 
 [CodeSystem]
 livd-device-type = 2.16.840.1.113883.4.642.40.51.16.1
@@ -36,4 +36,6 @@ ext-region = 2.16.840.1.113883.4.642.40.51.42.7
 ext-vendorReferenceIdentifier = 2.16.840.1.113883.4.642.40.51.42.8
 observationdefinition-uv-livd = 2.16.840.1.113883.4.642.40.51.42.9
 valueset-uv-livd = 2.16.840.1.113883.4.642.40.51.42.10
+ext-language = 2.16.840.1.113883.4.642.40.51.42.11
+ext-version = 2.16.840.1.113883.4.642.40.51.42.12
 

--- a/oids.ini
+++ b/oids.ini
@@ -10,7 +10,7 @@ information6 = There is never a reason to edit anything else
 CodeSystem = 2
 ValueSet = 4
 ConceptMap = 1
-StructureDefinition = 13
+StructureDefinition = 14
 
 [CodeSystem]
 livd-device-type = 2.16.840.1.113883.4.642.40.51.16.1
@@ -39,4 +39,5 @@ valueset-uv-livd = 2.16.840.1.113883.4.642.40.51.42.10
 ext-language = 2.16.840.1.113883.4.642.40.51.42.11
 ext-version = 2.16.840.1.113883.4.642.40.51.42.12
 ext-deviceDefinition-hasPart = 2.16.840.1.113883.4.642.40.51.42.13
+ext-deviceDefinition-classification-type = 2.16.840.1.113883.4.642.40.51.42.14
 

--- a/oids.ini
+++ b/oids.ini
@@ -10,7 +10,7 @@ information6 = There is never a reason to edit anything else
 CodeSystem = 2
 ValueSet = 4
 ConceptMap = 1
-StructureDefinition = 12
+StructureDefinition = 13
 
 [CodeSystem]
 livd-device-type = 2.16.840.1.113883.4.642.40.51.16.1
@@ -38,4 +38,5 @@ observationdefinition-uv-livd = 2.16.840.1.113883.4.642.40.51.42.9
 valueset-uv-livd = 2.16.840.1.113883.4.642.40.51.42.10
 ext-language = 2.16.840.1.113883.4.642.40.51.42.11
 ext-version = 2.16.840.1.113883.4.642.40.51.42.12
+ext-deviceDefinition-hasPart = 2.16.840.1.113883.4.642.40.51.42.13
 


### PR DESCRIPTION
### FHIR-44027 — `.signature` in Bundle missing
> Aligns `Bundle.signature` cardinality to `(0..1)` as specified in the LIVD Bundle Content Sample. The profile had incorrectly constrained it to `(0..0)`.

### FHIR-44137 — Wrong cardinality in ObservationDefinition
> Corrects cardinality mismatches between the LIVD Bundle Content Sample and the ObservationDefinition profile for `id`, `identifier`, `code.coding`, and the coding sub-elements (`system`, `code`, `display`).

### FHIR-50049 — ObservationDefinition vendor reference identifier was added
> Adds the vendor reference identifier extension to the ObservationDefinition profile per the mapping spreadsheet, and updates the spreadsheet accordingly.

### FHIR-44128 + FHIR-50031 *(duplicates)*
> Adds the missing R5 pre-adoption `note` extension `(0..*)` to the Catalog profile. FHIR-50031 is a duplicate of FHIR-44128.

### FHIR-44088 — Several extensions in LIVD Catalog missing
> Adds the missing `extension-version (1..1)` to the Catalog profile, and renames `language` → `ext-language` and `CatalogRegion` → `ext-region` to match the LIVD Bundle Content Sample.

### FHIR-43984 — Should further define valueset for composition.type for LIVD
> Restricts the value set for `Composition.type` to LIVD-appropriate catalog/compendium concepts. A LOINC code request has been submitted for the appropriate concept.

### FHIR-30422 — DeviceDefinition configuration
> Adds an extension to associate a device with multiple instrument-test-combinations, replacing the `parentDevice` Must Support approach which is not applicable in R4.

### FHIR-44133 + FHIR-50039 + FHIR-50040 *(duplicates)*
> Adds the two missing R5 pre-adoption extensions to the DeviceDefinition profile: `classification (1..*)` and `hasPart (0..*)`. FHIR-50039 and FHIR-50040 each reported one of these individually and are duplicates of FHIR-44133.